### PR TITLE
fix: self.nextの時刻更新後にpresenceの表示時刻を更新する

### DIFF
--- a/src/cogs/salmon_cog.py
+++ b/src/cogs/salmon_cog.py
@@ -44,7 +44,6 @@ class SalmonCog(commands.Cog):
     @tasks.loop(minutes=3)
     async def notif(self):
         now = datetime.now(tz=tz_jst)
-        await self.update_presence()
         if self.next < now:
             txt, self.next = maketext()
             if not self.next:
@@ -52,6 +51,7 @@ class SalmonCog(commands.Cog):
             for channel_id in self.channels:
                 channel = self.bot.get_channel(channel_id)
                 await channel.send(txt)
+        await self.update_presence()
 
     @app_commands.command(name="notif_set", description="通知設定を追加します。")
     async def notif_set(self, interaction: discord.Interaction):


### PR DESCRIPTION
プレイ中の時刻が時刻更新順の関係でマイナス表示になってしまうのを修正
![image](https://github.com/user-attachments/assets/614c0b00-664f-4965-be9e-d437238b54f1)
